### PR TITLE
Add eslint icon to file "eslint.config.js"

### DIFF
--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -112,6 +112,7 @@ export default {
   ".eslintrc.yaml": "_f_eslint",
   ".eslintrc.yml": "_f_eslint",
   "eslint-preset.js": "_f_eslint",
+  "eslint.config.js": "_f_eslint",
   "app.json": "_f_expo",
   "app.config.js": "_f_expo",
   "app.config.json": "_f_expo",


### PR DESCRIPTION
This fixes https://github.com/BeardedBear/bearded-icons/issues/88. Add "eslint.config.js" to the list of file names that should have the ESLint icon (currently it has a regular JS icon)
