### PR TITLE
prettier & nextjs icons 

### DIFF
--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -327,6 +327,7 @@ export default {
   ".prettierrc": "_f_prettier",
   ".prettierignore": "_f_prettierignore",
   "prettier.config.js": "_f_prettier",
+  "prettier.config.cjs": "_f_prettier",
   "prettier.config.ts": "_f_prettier",
   "prettier.config.coffee": "_f_prettier",
   ".prettierrc.js": "_f_prettier",

--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -533,6 +533,7 @@ export default {
   "tauri.windows.conf.json": "_f_tauri",
   "tauri.macos.conf.json": "_f_tauri",
   "next.config.js": "_f_nextconfig",
+  "next.config.mjs": "_f_nextconfig",
   "next.config.ts": "_f_nextconfig",
   "nextron.config.js": "_f_nextron",
   "nextron.config.ts": "_f_nextron",


### PR DESCRIPTION
Changes "prettier.config.cjs" & "next.config.mjs" icons from default JS icon