### PR TITLE
Map .env.dist and .env.default to the env icon

### DIFF
--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -505,6 +505,8 @@ export default {
   ".env.development": "_f_env",
   ".env.example": "_f_env",
   ".env.test": "_f_env",
+  ".env.dist": "_f_env",
+  ".env.default": "_f_env",
   ".jinja": "_f_jinja",
   "jenkins.yaml": "_f_jenkins",
   "jenkins.yml": "_f_jenkins",


### PR DESCRIPTION
Several repos I have encountered use `.env.dist` and `.env.default` for the distributed `.env` file and it would be nice if they were displayed with the env icon as well.