### PR TITLE
adds eslint icon to file "_eslintrc.cjs"

### DIFF
--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -109,6 +109,7 @@ export default {
   ".eslintrc.js": "_f_eslint",
   ".eslintrc.mjs": "_f_eslint",
   ".eslintrc.cjs": "_f_eslint",
+  "_eslintrc.cjs": "_f_eslint",
   ".eslintrc.json": "_f_eslint",
   ".eslintrc.yaml": "_f_eslint",
   ".eslintrc.yml": "_f_eslint",


### PR DESCRIPTION
Updates _eslintrc.cjs from default js icon.

File used in popular fullstack typescript scaffold [create-t3-app](https://github.com/t3-oss/create-t3-app) .