### PR TITLE
Added LLVM icon to ".clangd" files

### DIFF
--- a/src/shared/fileNames.ts
+++ b/src/shared/fileNames.ts
@@ -597,6 +597,7 @@ export default {
   "bsconfig.json": "bsconfig",
   ".clang-format": "llvm",
   ".clang-tidy": "llvm",
+  ".clangd": "llvm",
   ".parcelrc": "parcel",
   dune: "dune",
   "dune-project": "duneproject",


### PR DESCRIPTION
Hi! Nice icon theme!
I only miss the LLVM icon on .clangd files, which are configs for the Clangd C/C++ language server.